### PR TITLE
Change billing options to free

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,5 +27,8 @@
       }
     }
   ],
+  "billingOptions": {
+    "type": "free"
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
**What problem is this solving?**

As most of the connectors want to be published to all accounts, we are setting the default example with `billingOptions: free` to avoid private app installation problems.

**How should this be manually tested?**

**Screenshots or example usage:**